### PR TITLE
Add evaluation datasources and exports

### DIFF
--- a/clean/src/domain/datasources/evaluacion/calificacion.datasource.ts
+++ b/clean/src/domain/datasources/evaluacion/calificacion.datasource.ts
@@ -1,0 +1,9 @@
+import { Calificacion } from '../entities/evaluacion/calificacion.entity';
+
+export abstract class CalificacionDatasource {
+  abstract create(calificacion: Calificacion): Promise<Calificacion>;
+  abstract getAll(): Promise<Calificacion[]>;
+  abstract findById(id: number): Promise<Calificacion>;
+  abstract update(calificacion: Calificacion): Promise<Calificacion>;
+  abstract deleteById(id: number): Promise<Calificacion>;
+}

--- a/clean/src/domain/datasources/evaluacion/criterio-evaluacion.datasource.ts
+++ b/clean/src/domain/datasources/evaluacion/criterio-evaluacion.datasource.ts
@@ -1,0 +1,9 @@
+import { CriterioEvaluacion } from '../entities/evaluacion/criterio-evaluacion.entity';
+
+export abstract class CriterioEvaluacionDatasource {
+  abstract create(criterio: CriterioEvaluacion): Promise<CriterioEvaluacion>;
+  abstract getAll(): Promise<CriterioEvaluacion[]>;
+  abstract findById(id: number): Promise<CriterioEvaluacion>;
+  abstract update(criterio: CriterioEvaluacion): Promise<CriterioEvaluacion>;
+  abstract deleteById(id: number): Promise<CriterioEvaluacion>;
+}

--- a/clean/src/domain/datasources/evaluacion/detalle-calificacion.datasource.ts
+++ b/clean/src/domain/datasources/evaluacion/detalle-calificacion.datasource.ts
@@ -1,0 +1,9 @@
+import { DetalleCalificacion } from '../entities/evaluacion/detalle-calificacion.entity';
+
+export abstract class DetalleCalificacionDatasource {
+  abstract create(detalle: DetalleCalificacion): Promise<DetalleCalificacion>;
+  abstract getAll(): Promise<DetalleCalificacion[]>;
+  abstract findById(id: number): Promise<DetalleCalificacion>;
+  abstract update(detalle: DetalleCalificacion): Promise<DetalleCalificacion>;
+  abstract deleteById(id: number): Promise<DetalleCalificacion>;
+}

--- a/clean/src/domain/datasources/evaluacion/feedback-calificacion.datasource.ts
+++ b/clean/src/domain/datasources/evaluacion/feedback-calificacion.datasource.ts
@@ -1,0 +1,9 @@
+import { FeedbackCalificacion } from '../entities/evaluacion/feedback-calificacion.entity';
+
+export abstract class FeedbackCalificacionDatasource {
+  abstract create(feedback: FeedbackCalificacion): Promise<FeedbackCalificacion>;
+  abstract getAll(): Promise<FeedbackCalificacion[]>;
+  abstract findById(id: number): Promise<FeedbackCalificacion>;
+  abstract update(feedback: FeedbackCalificacion): Promise<FeedbackCalificacion>;
+  abstract deleteById(id: number): Promise<FeedbackCalificacion>;
+}

--- a/clean/src/domain/datasources/evaluacion/parametros-ideales.datasource.ts
+++ b/clean/src/domain/datasources/evaluacion/parametros-ideales.datasource.ts
@@ -1,0 +1,9 @@
+import { ParametrosIdeales } from '../entities/evaluacion/parametros-ideales.entity';
+
+export abstract class ParametrosIdealesDatasource {
+  abstract create(param: ParametrosIdeales): Promise<ParametrosIdeales>;
+  abstract getAll(): Promise<ParametrosIdeales[]>;
+  abstract findById(id: number): Promise<ParametrosIdeales>;
+  abstract update(param: ParametrosIdeales): Promise<ParametrosIdeales>;
+  abstract deleteById(id: number): Promise<ParametrosIdeales>;
+}

--- a/clean/src/domain/entities/evaluacion/calificacion.entity.ts
+++ b/clean/src/domain/entities/evaluacion/calificacion.entity.ts
@@ -1,0 +1,56 @@
+import { ParametrosIdeales } from './parametros-ideales.entity';
+
+export class Calificacion {
+  constructor(
+    public readonly id: number,
+    public readonly grabacionId: number,
+    public readonly usuarioId: number,
+    public readonly puntajeGlobal: number,
+    public readonly observacionGlobal: string,
+    public readonly tipoCalificacion: string,
+    public readonly fecha: Date,
+    public readonly parametrosIdeales?: ParametrosIdeales,
+  ) {}
+
+  get hasParametros() {
+    return !!this.parametrosIdeales;
+  }
+
+  static fromObject(obj: Record<string, any>): Calificacion {
+    const {
+      id,
+      grabacionId,
+      usuarioId,
+      puntajeGlobal,
+      observacionGlobal,
+      tipoCalificacion,
+      fecha,
+      parametrosIdeales,
+    } = obj;
+
+    if (id === undefined) throw 'id is required';
+    if (grabacionId === undefined) throw 'grabacionId is required';
+    if (usuarioId === undefined) throw 'usuarioId is required';
+    if (puntajeGlobal === undefined) throw 'puntajeGlobal is required';
+    if (!tipoCalificacion) throw 'tipoCalificacion is required';
+    if (!fecha) throw 'fecha is required';
+
+    const date = new Date(fecha);
+    if (isNaN(date.getTime())) throw 'fecha is not valid';
+
+    const param = parametrosIdeales
+      ? ParametrosIdeales.fromObject(parametrosIdeales)
+      : undefined;
+
+    return new Calificacion(
+      id,
+      grabacionId,
+      usuarioId,
+      puntajeGlobal,
+      observacionGlobal ?? '',
+      tipoCalificacion,
+      date,
+      param
+    );
+  }
+}

--- a/clean/src/domain/entities/evaluacion/criterio-evaluacion.entity.ts
+++ b/clean/src/domain/entities/evaluacion/criterio-evaluacion.entity.ts
@@ -1,0 +1,17 @@
+export class CriterioEvaluacion {
+  constructor(
+    public readonly id: number,
+    public readonly nombre: string,
+    public readonly descripcion: string,
+    public readonly peso: number,
+  ) {}
+
+  static fromObject(obj: Record<string, any>): CriterioEvaluacion {
+    const { id, nombre, descripcion, peso } = obj;
+    if (id === undefined) throw 'id is required';
+    if (!nombre) throw 'nombre is required';
+    if (peso === undefined) throw 'peso is required';
+    const desc = descripcion ?? '';
+    return new CriterioEvaluacion(id, nombre, desc, peso);
+  }
+}

--- a/clean/src/domain/entities/evaluacion/detalle-calificacion.entity.ts
+++ b/clean/src/domain/entities/evaluacion/detalle-calificacion.entity.ts
@@ -1,0 +1,43 @@
+import { Calificacion } from './calificacion.entity';
+import { CriterioEvaluacion } from './criterio-evaluacion.entity';
+
+export class DetalleCalificacion {
+  constructor(
+    public readonly id: number,
+    public readonly calificacion: Calificacion,
+    public readonly criterioEvaluacion: CriterioEvaluacion,
+    public readonly slideId: number,
+    public readonly puntaje: number,
+    public readonly comentario: string,
+    public readonly fragmentoAudioId: number,
+  ) {}
+
+  static fromObject(obj: Record<string, any>): DetalleCalificacion {
+    const {
+      id,
+      calificacion,
+      criterioEvaluacion,
+      slideId,
+      puntaje,
+      comentario,
+      fragmentoAudioId,
+    } = obj;
+
+    if (id === undefined) throw 'id is required';
+    if (!calificacion) throw 'calificacion is required';
+    if (!criterioEvaluacion) throw 'criterioEvaluacion is required';
+    if (slideId === undefined) throw 'slideId is required';
+    if (puntaje === undefined) throw 'puntaje is required';
+    if (fragmentoAudioId === undefined) throw 'fragmentoAudioId is required';
+
+    return new DetalleCalificacion(
+      id,
+      Calificacion.fromObject(calificacion),
+      CriterioEvaluacion.fromObject(criterioEvaluacion),
+      slideId,
+      puntaje,
+      comentario ?? '',
+      fragmentoAudioId
+    );
+  }
+}

--- a/clean/src/domain/entities/evaluacion/feedback-calificacion.entity.ts
+++ b/clean/src/domain/entities/evaluacion/feedback-calificacion.entity.ts
@@ -1,0 +1,28 @@
+import { Calificacion } from './calificacion.entity';
+
+export class FeedbackCalificacion {
+  constructor(
+    public readonly id: number,
+    public readonly calificacion: Calificacion,
+    public readonly observacion: string,
+    public readonly fecha: Date,
+    public readonly autor: string,
+  ) {}
+
+  static fromObject(obj: Record<string, any>): FeedbackCalificacion {
+    const { id, calificacion, observacion, fecha, autor } = obj;
+    if (id === undefined) throw 'id is required';
+    if (!calificacion) throw 'calificacion is required';
+    if (!fecha) throw 'fecha is required';
+    const date = new Date(fecha);
+    if (isNaN(date.getTime())) throw 'fecha is not valid';
+
+    return new FeedbackCalificacion(
+      id,
+      Calificacion.fromObject(calificacion),
+      observacion ?? '',
+      date,
+      autor ?? ''
+    );
+  }
+}

--- a/clean/src/domain/entities/evaluacion/parametros-ideales.entity.ts
+++ b/clean/src/domain/entities/evaluacion/parametros-ideales.entity.ts
@@ -1,0 +1,19 @@
+export class ParametrosIdeales {
+  constructor(
+    public readonly id: number,
+    public readonly claridadIdeal: number,
+    public readonly velocidadIdeal: number,
+    public readonly pausasIdeales: number,
+    public readonly otrosParametros: string,
+  ) {}
+
+  static fromObject(obj: Record<string, any>): ParametrosIdeales {
+    const { id, claridadIdeal, velocidadIdeal, pausasIdeales, otrosParametros } = obj;
+    if (id === undefined) throw 'id is required';
+    if (claridadIdeal === undefined) throw 'claridadIdeal is required';
+    if (velocidadIdeal === undefined) throw 'velocidadIdeal is required';
+    if (pausasIdeales === undefined) throw 'pausasIdeales is required';
+    const otros = otrosParametros ?? '';
+    return new ParametrosIdeales(id, claridadIdeal, velocidadIdeal, pausasIdeales, otros);
+  }
+}

--- a/clean/src/domain/index.ts
+++ b/clean/src/domain/index.ts
@@ -13,3 +13,22 @@ export * from './use-cases/todo/get-todo';
 export * from './use-cases/todo/get-todos';
 
 
+
+// Evaluacion domain exports
+export * from './entities/evaluacion/calificacion.entity';
+export * from './entities/evaluacion/criterio-evaluacion.entity';
+export * from './entities/evaluacion/detalle-calificacion.entity';
+export * from './entities/evaluacion/feedback-calificacion.entity';
+export * from './entities/evaluacion/parametros-ideales.entity';
+
+export * from './repositories/evaluacion/calificacion.repository';
+export * from './repositories/evaluacion/criterio-evaluacion.repository';
+export * from './repositories/evaluacion/detalle-calificacion.repository';
+export * from './repositories/evaluacion/feedback-calificacion.repository';
+export * from './repositories/evaluacion/parametros-ideales.repository';
+
+export * from './datasources/evaluacion/calificacion.datasource';
+export * from './datasources/evaluacion/criterio-evaluacion.datasource';
+export * from './datasources/evaluacion/detalle-calificacion.datasource';
+export * from './datasources/evaluacion/feedback-calificacion.datasource';
+export * from './datasources/evaluacion/parametros-ideales.datasource';

--- a/clean/src/domain/repositories/evaluacion/calificacion.repository.ts
+++ b/clean/src/domain/repositories/evaluacion/calificacion.repository.ts
@@ -1,0 +1,9 @@
+import { Calificacion } from '../../entities/evaluacion/calificacion.entity';
+
+export abstract class CalificacionRepository {
+  abstract create(calificacion: Calificacion): Promise<Calificacion>;
+  abstract getAll(): Promise<Calificacion[]>;
+  abstract findById(id: number): Promise<Calificacion>;
+  abstract update(calificacion: Calificacion): Promise<Calificacion>;
+  abstract deleteById(id: number): Promise<Calificacion>;
+}

--- a/clean/src/domain/repositories/evaluacion/criterio-evaluacion.repository.ts
+++ b/clean/src/domain/repositories/evaluacion/criterio-evaluacion.repository.ts
@@ -1,0 +1,9 @@
+import { CriterioEvaluacion } from '../../entities/evaluacion/criterio-evaluacion.entity';
+
+export abstract class CriterioEvaluacionRepository {
+  abstract create(criterio: CriterioEvaluacion): Promise<CriterioEvaluacion>;
+  abstract getAll(): Promise<CriterioEvaluacion[]>;
+  abstract findById(id: number): Promise<CriterioEvaluacion>;
+  abstract update(criterio: CriterioEvaluacion): Promise<CriterioEvaluacion>;
+  abstract deleteById(id: number): Promise<CriterioEvaluacion>;
+}

--- a/clean/src/domain/repositories/evaluacion/detalle-calificacion.repository.ts
+++ b/clean/src/domain/repositories/evaluacion/detalle-calificacion.repository.ts
@@ -1,0 +1,9 @@
+import { DetalleCalificacion } from '../../entities/evaluacion/detalle-calificacion.entity';
+
+export abstract class DetalleCalificacionRepository {
+  abstract create(detalle: DetalleCalificacion): Promise<DetalleCalificacion>;
+  abstract getAll(): Promise<DetalleCalificacion[]>;
+  abstract findById(id: number): Promise<DetalleCalificacion>;
+  abstract update(detalle: DetalleCalificacion): Promise<DetalleCalificacion>;
+  abstract deleteById(id: number): Promise<DetalleCalificacion>;
+}

--- a/clean/src/domain/repositories/evaluacion/feedback-calificacion.repository.ts
+++ b/clean/src/domain/repositories/evaluacion/feedback-calificacion.repository.ts
@@ -1,0 +1,9 @@
+import { FeedbackCalificacion } from '../../entities/evaluacion/feedback-calificacion.entity';
+
+export abstract class FeedbackCalificacionRepository {
+  abstract create(feedback: FeedbackCalificacion): Promise<FeedbackCalificacion>;
+  abstract getAll(): Promise<FeedbackCalificacion[]>;
+  abstract findById(id: number): Promise<FeedbackCalificacion>;
+  abstract update(feedback: FeedbackCalificacion): Promise<FeedbackCalificacion>;
+  abstract deleteById(id: number): Promise<FeedbackCalificacion>;
+}

--- a/clean/src/domain/repositories/evaluacion/parametros-ideales.repository.ts
+++ b/clean/src/domain/repositories/evaluacion/parametros-ideales.repository.ts
@@ -1,0 +1,9 @@
+import { ParametrosIdeales } from '../../entities/evaluacion/parametros-ideales.entity';
+
+export abstract class ParametrosIdealesRepository {
+  abstract create(param: ParametrosIdeales): Promise<ParametrosIdeales>;
+  abstract getAll(): Promise<ParametrosIdeales[]>;
+  abstract findById(id: number): Promise<ParametrosIdeales>;
+  abstract update(param: ParametrosIdeales): Promise<ParametrosIdeales>;
+  abstract deleteById(id: number): Promise<ParametrosIdeales>;
+}


### PR DESCRIPTION
## Summary
- add datasource abstractions for evaluation domain
- export evaluation datasources in `domain/index.ts`

## Testing
- `npx tsc` *(fails: Cannot find module / types)*

------
https://chatgpt.com/codex/tasks/task_e_6846eba2178c832b9eff5173c0838899