### PR TITLE
Document domain entities and add DTOs

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,17 @@ Puedes usar el archivo `memory-datasource.http` para probar la funcionalidad con
 - [Memory Datasource Guide](./MEMORY_DATASOURCE.md) - Guía completa del datasource de memoria
 - [memory-datasource.http](./memory-datasource.http) - Ejemplos de peticiones HTTP
 
+## Entidades del Dominio
+
+| Entidad | Descripción | Justificación |
+|---------|-------------|---------------|
+| **TodoEntity** | Representa una tarea por realizar con su texto y fecha de finalización opcional. | Sirve como ejemplo simple para exponer la arquitectura y probar los distintos datasources. |
+| **Calificacion** | Calificación global de una grabación realizada por un usuario, incluye puntaje, observaciones y fecha. | Permite almacenar la evaluación general y actúa como agregador de los detalles de cada criterio. |
+| **CriterioEvaluacion** | Define un criterio o aspecto a evaluar junto con su peso relativo. | Separa los distintos puntos que componen una calificación para un análisis más fino. |
+| **DetalleCalificacion** | Puntaje otorgado a un criterio en una diapositiva específica junto con comentarios y audio. | Registra la evaluación a nivel de detalle para identificar fortalezas y debilidades puntuales. |
+| **FeedbackCalificacion** | Retroalimentación textual asociada a una calificación en una fecha determinada. | Permite mantener un historial de comentarios y sugerencias sobre la presentación evaluada. |
+| **ParametrosIdeales** | Valores ideales de claridad, velocidad y pausas utilizados como referencia. | Sirven como guía para comparar las presentaciones contra un estándar deseado. |
+
 ## Aplicación de Flashcards
 
 La primera imagen muestra un listado de flashcards para la administración de los usuarios.

--- a/clean/README.md
+++ b/clean/README.md
@@ -154,6 +154,17 @@ Puedes usar el archivo `memory-datasource.http` para probar la funcionalidad con
 - [Memory Datasource Guide](./MEMORY_DATASOURCE.md) - Guía completa del datasource de memoria
 - [memory-datasource.http](./memory-datasource.http) - Ejemplos de peticiones HTTP
 
+## Entidades del Dominio
+
+| Entidad | Descripción | Justificación |
+|---------|-------------|---------------|
+| **TodoEntity** | Representa una tarea por realizar con su texto y fecha de finalización opcional. | Sirve como ejemplo simple para exponer la arquitectura y probar los distintos datasources. |
+| **Calificacion** | Calificación global de una grabación realizada por un usuario, incluye puntaje, observaciones y fecha. | Permite almacenar la evaluación general y actúa como agregador de los detalles de cada criterio. |
+| **CriterioEvaluacion** | Define un criterio o aspecto a evaluar junto con su peso relativo. | Separa los distintos puntos que componen una calificación para un análisis más fino. |
+| **DetalleCalificacion** | Puntaje otorgado a un criterio en una diapositiva específica junto con comentarios y audio. | Registra la evaluación a nivel de detalle para identificar fortalezas y debilidades puntuales. |
+| **FeedbackCalificacion** | Retroalimentación textual asociada a una calificación en una fecha determinada. | Permite mantener un historial de comentarios y sugerencias sobre la presentación evaluada. |
+| **ParametrosIdeales** | Valores ideales de claridad, velocidad y pausas utilizados como referencia. | Sirven como guía para comparar las presentaciones contra un estándar deseado. |
+
 ## Aplicación de Flashcards
 
 La primera imagen muestra un listado de flashcards para la administración de los usuarios.

--- a/clean/src/domain/datasources/evaluacion/calificacion.datasource.ts
+++ b/clean/src/domain/datasources/evaluacion/calificacion.datasource.ts
@@ -1,4 +1,4 @@
-import { Calificacion } from '../entities/evaluacion/calificacion.entity';
+import { Calificacion } from '../../entities/evaluacion/calificacion.entity';
 
 export abstract class CalificacionDatasource {
   abstract create(calificacion: Calificacion): Promise<Calificacion>;

--- a/clean/src/domain/datasources/evaluacion/criterio-evaluacion.datasource.ts
+++ b/clean/src/domain/datasources/evaluacion/criterio-evaluacion.datasource.ts
@@ -1,4 +1,4 @@
-import { CriterioEvaluacion } from '../entities/evaluacion/criterio-evaluacion.entity';
+import { CriterioEvaluacion } from '../../entities/evaluacion/criterio-evaluacion.entity';
 
 export abstract class CriterioEvaluacionDatasource {
   abstract create(criterio: CriterioEvaluacion): Promise<CriterioEvaluacion>;

--- a/clean/src/domain/datasources/evaluacion/detalle-calificacion.datasource.ts
+++ b/clean/src/domain/datasources/evaluacion/detalle-calificacion.datasource.ts
@@ -1,4 +1,4 @@
-import { DetalleCalificacion } from '../entities/evaluacion/detalle-calificacion.entity';
+import { DetalleCalificacion } from '../../entities/evaluacion/detalle-calificacion.entity';
 
 export abstract class DetalleCalificacionDatasource {
   abstract create(detalle: DetalleCalificacion): Promise<DetalleCalificacion>;

--- a/clean/src/domain/datasources/evaluacion/feedback-calificacion.datasource.ts
+++ b/clean/src/domain/datasources/evaluacion/feedback-calificacion.datasource.ts
@@ -1,4 +1,4 @@
-import { FeedbackCalificacion } from '../entities/evaluacion/feedback-calificacion.entity';
+import { FeedbackCalificacion } from '../../entities/evaluacion/feedback-calificacion.entity';
 
 export abstract class FeedbackCalificacionDatasource {
   abstract create(feedback: FeedbackCalificacion): Promise<FeedbackCalificacion>;

--- a/clean/src/domain/datasources/evaluacion/parametros-ideales.datasource.ts
+++ b/clean/src/domain/datasources/evaluacion/parametros-ideales.datasource.ts
@@ -1,4 +1,4 @@
-import { ParametrosIdeales } from '../entities/evaluacion/parametros-ideales.entity';
+import { ParametrosIdeales } from '../../entities/evaluacion/parametros-ideales.entity';
 
 export abstract class ParametrosIdealesDatasource {
   abstract create(param: ParametrosIdeales): Promise<ParametrosIdeales>;

--- a/clean/src/domain/dtos/evaluacion/create-calificacion.dto.ts
+++ b/clean/src/domain/dtos/evaluacion/create-calificacion.dto.ts
@@ -1,0 +1,45 @@
+export class CreateCalificacionDto {
+  private constructor(
+    public readonly grabacionId: number,
+    public readonly usuarioId: number,
+    public readonly puntajeGlobal: number,
+    public readonly observacionGlobal: string,
+    public readonly tipoCalificacion: string,
+    public readonly fecha: Date,
+    public readonly parametrosIdealesId?: number,
+  ) {}
+
+  static create(props: { [key: string]: any }): [string?, CreateCalificacionDto?] {
+    const {
+      grabacionId,
+      usuarioId,
+      puntajeGlobal,
+      observacionGlobal,
+      tipoCalificacion,
+      fecha,
+      parametrosIdealesId,
+    } = props;
+
+    if (grabacionId === undefined) return ['grabacionId is required'];
+    if (usuarioId === undefined) return ['usuarioId is required'];
+    if (puntajeGlobal === undefined) return ['puntajeGlobal is required'];
+    if (!tipoCalificacion) return ['tipoCalificacion is required'];
+    if (!fecha) return ['fecha is required'];
+
+    const parsedDate = new Date(fecha);
+    if (parsedDate.toString() === 'Invalid Date') return ['fecha must be a valid date'];
+
+    return [
+      undefined,
+      new CreateCalificacionDto(
+        Number(grabacionId),
+        Number(usuarioId),
+        Number(puntajeGlobal),
+        observacionGlobal ?? '',
+        tipoCalificacion,
+        parsedDate,
+        parametrosIdealesId !== undefined ? Number(parametrosIdealesId) : undefined,
+      ),
+    ];
+  }
+}

--- a/clean/src/domain/dtos/evaluacion/create-criterio-evaluacion.dto.ts
+++ b/clean/src/domain/dtos/evaluacion/create-criterio-evaluacion.dto.ts
@@ -1,0 +1,14 @@
+export class CreateCriterioEvaluacionDto {
+  private constructor(
+    public readonly nombre: string,
+    public readonly descripcion: string,
+    public readonly peso: number,
+  ) {}
+
+  static create(props: { [key: string]: any }): [string?, CreateCriterioEvaluacionDto?] {
+    const { nombre, descripcion, peso } = props;
+    if (!nombre) return ['nombre is required'];
+    if (peso === undefined) return ['peso is required'];
+    return [undefined, new CreateCriterioEvaluacionDto(nombre, descripcion ?? '', Number(peso))];
+  }
+}

--- a/clean/src/domain/dtos/evaluacion/create-detalle-calificacion.dto.ts
+++ b/clean/src/domain/dtos/evaluacion/create-detalle-calificacion.dto.ts
@@ -1,0 +1,39 @@
+export class CreateDetalleCalificacionDto {
+  private constructor(
+    public readonly calificacionId: number,
+    public readonly criterioEvaluacionId: number,
+    public readonly slideId: number,
+    public readonly puntaje: number,
+    public readonly comentario: string,
+    public readonly fragmentoAudioId: number,
+  ) {}
+
+  static create(props: { [key: string]: any }): [string?, CreateDetalleCalificacionDto?] {
+    const {
+      calificacionId,
+      criterioEvaluacionId,
+      slideId,
+      puntaje,
+      comentario,
+      fragmentoAudioId,
+    } = props;
+
+    if (calificacionId === undefined) return ['calificacionId is required'];
+    if (criterioEvaluacionId === undefined) return ['criterioEvaluacionId is required'];
+    if (slideId === undefined) return ['slideId is required'];
+    if (puntaje === undefined) return ['puntaje is required'];
+    if (fragmentoAudioId === undefined) return ['fragmentoAudioId is required'];
+
+    return [
+      undefined,
+      new CreateDetalleCalificacionDto(
+        Number(calificacionId),
+        Number(criterioEvaluacionId),
+        Number(slideId),
+        Number(puntaje),
+        comentario ?? '',
+        Number(fragmentoAudioId),
+      ),
+    ];
+  }
+}

--- a/clean/src/domain/dtos/evaluacion/create-feedback-calificacion.dto.ts
+++ b/clean/src/domain/dtos/evaluacion/create-feedback-calificacion.dto.ts
@@ -1,0 +1,27 @@
+export class CreateFeedbackCalificacionDto {
+  private constructor(
+    public readonly calificacionId: number,
+    public readonly observacion: string,
+    public readonly fecha: Date,
+    public readonly autor: string,
+  ) {}
+
+  static create(props: { [key: string]: any }): [string?, CreateFeedbackCalificacionDto?] {
+    const { calificacionId, observacion, fecha, autor } = props;
+    if (calificacionId === undefined) return ['calificacionId is required'];
+    if (!fecha) return ['fecha is required'];
+
+    const parsedDate = new Date(fecha);
+    if (parsedDate.toString() === 'Invalid Date') return ['fecha must be a valid date'];
+
+    return [
+      undefined,
+      new CreateFeedbackCalificacionDto(
+        Number(calificacionId),
+        observacion ?? '',
+        parsedDate,
+        autor ?? '',
+      ),
+    ];
+  }
+}

--- a/clean/src/domain/dtos/evaluacion/create-parametros-ideales.dto.ts
+++ b/clean/src/domain/dtos/evaluacion/create-parametros-ideales.dto.ts
@@ -1,0 +1,25 @@
+export class CreateParametrosIdealesDto {
+  private constructor(
+    public readonly claridadIdeal: number,
+    public readonly velocidadIdeal: number,
+    public readonly pausasIdeales: number,
+    public readonly otrosParametros: string,
+  ) {}
+
+  static create(props: { [key: string]: any }): [string?, CreateParametrosIdealesDto?] {
+    const { claridadIdeal, velocidadIdeal, pausasIdeales, otrosParametros } = props;
+    if (claridadIdeal === undefined) return ['claridadIdeal is required'];
+    if (velocidadIdeal === undefined) return ['velocidadIdeal is required'];
+    if (pausasIdeales === undefined) return ['pausasIdeales is required'];
+
+    return [
+      undefined,
+      new CreateParametrosIdealesDto(
+        Number(claridadIdeal),
+        Number(velocidadIdeal),
+        Number(pausasIdeales),
+        otrosParametros ?? '',
+      ),
+    ];
+  }
+}

--- a/clean/src/domain/dtos/evaluacion/update-calificacion.dto.ts
+++ b/clean/src/domain/dtos/evaluacion/update-calificacion.dto.ts
@@ -1,0 +1,59 @@
+export class UpdateCalificacionDto {
+  private constructor(
+    public readonly id: number,
+    public readonly grabacionId?: number,
+    public readonly usuarioId?: number,
+    public readonly puntajeGlobal?: number,
+    public readonly observacionGlobal?: string,
+    public readonly tipoCalificacion?: string,
+    public readonly fecha?: Date,
+    public readonly parametrosIdealesId?: number,
+  ) {}
+
+  get values() {
+    const obj: { [key: string]: any } = {};
+    if (this.grabacionId !== undefined) obj.grabacionId = this.grabacionId;
+    if (this.usuarioId !== undefined) obj.usuarioId = this.usuarioId;
+    if (this.puntajeGlobal !== undefined) obj.puntajeGlobal = this.puntajeGlobal;
+    if (this.observacionGlobal !== undefined) obj.observacionGlobal = this.observacionGlobal;
+    if (this.tipoCalificacion !== undefined) obj.tipoCalificacion = this.tipoCalificacion;
+    if (this.fecha) obj.fecha = this.fecha;
+    if (this.parametrosIdealesId !== undefined) obj.parametrosIdealesId = this.parametrosIdealesId;
+    return obj;
+  }
+
+  static create(props: { [key: string]: any }): [string?, UpdateCalificacionDto?] {
+    const {
+      id,
+      grabacionId,
+      usuarioId,
+      puntajeGlobal,
+      observacionGlobal,
+      tipoCalificacion,
+      fecha,
+      parametrosIdealesId,
+    } = props;
+
+    if (id === undefined || isNaN(Number(id))) return ['id must be a valid number'];
+
+    let parsedDate: Date | undefined = undefined;
+    if (fecha) {
+      parsedDate = new Date(fecha);
+      if (parsedDate.toString() === 'Invalid Date') return ['fecha must be a valid date'];
+    }
+
+    return [
+      undefined,
+      new UpdateCalificacionDto(
+        Number(id),
+        grabacionId !== undefined ? Number(grabacionId) : undefined,
+        usuarioId !== undefined ? Number(usuarioId) : undefined,
+        puntajeGlobal !== undefined ? Number(puntajeGlobal) : undefined,
+        observacionGlobal,
+        tipoCalificacion,
+        parsedDate,
+        parametrosIdealesId !== undefined ? Number(parametrosIdealesId) : undefined,
+      ),
+    ];
+  }
+}

--- a/clean/src/domain/dtos/evaluacion/update-criterio-evaluacion.dto.ts
+++ b/clean/src/domain/dtos/evaluacion/update-criterio-evaluacion.dto.ts
@@ -1,0 +1,30 @@
+export class UpdateCriterioEvaluacionDto {
+  private constructor(
+    public readonly id: number,
+    public readonly nombre?: string,
+    public readonly descripcion?: string,
+    public readonly peso?: number,
+  ) {}
+
+  get values() {
+    const obj: { [key: string]: any } = {};
+    if (this.nombre !== undefined) obj.nombre = this.nombre;
+    if (this.descripcion !== undefined) obj.descripcion = this.descripcion;
+    if (this.peso !== undefined) obj.peso = this.peso;
+    return obj;
+  }
+
+  static create(props: { [key: string]: any }): [string?, UpdateCriterioEvaluacionDto?] {
+    const { id, nombre, descripcion, peso } = props;
+    if (id === undefined || isNaN(Number(id))) return ['id must be a valid number'];
+    return [
+      undefined,
+      new UpdateCriterioEvaluacionDto(
+        Number(id),
+        nombre,
+        descripcion,
+        peso !== undefined ? Number(peso) : undefined,
+      ),
+    ];
+  }
+}

--- a/clean/src/domain/dtos/evaluacion/update-detalle-calificacion.dto.ts
+++ b/clean/src/domain/dtos/evaluacion/update-detalle-calificacion.dto.ts
@@ -1,0 +1,49 @@
+export class UpdateDetalleCalificacionDto {
+  private constructor(
+    public readonly id: number,
+    public readonly calificacionId?: number,
+    public readonly criterioEvaluacionId?: number,
+    public readonly slideId?: number,
+    public readonly puntaje?: number,
+    public readonly comentario?: string,
+    public readonly fragmentoAudioId?: number,
+  ) {}
+
+  get values() {
+    const obj: { [key: string]: any } = {};
+    if (this.calificacionId !== undefined) obj.calificacionId = this.calificacionId;
+    if (this.criterioEvaluacionId !== undefined) obj.criterioEvaluacionId = this.criterioEvaluacionId;
+    if (this.slideId !== undefined) obj.slideId = this.slideId;
+    if (this.puntaje !== undefined) obj.puntaje = this.puntaje;
+    if (this.comentario !== undefined) obj.comentario = this.comentario;
+    if (this.fragmentoAudioId !== undefined) obj.fragmentoAudioId = this.fragmentoAudioId;
+    return obj;
+  }
+
+  static create(props: { [key: string]: any }): [string?, UpdateDetalleCalificacionDto?] {
+    const {
+      id,
+      calificacionId,
+      criterioEvaluacionId,
+      slideId,
+      puntaje,
+      comentario,
+      fragmentoAudioId,
+    } = props;
+
+    if (id === undefined || isNaN(Number(id))) return ['id must be a valid number'];
+
+    return [
+      undefined,
+      new UpdateDetalleCalificacionDto(
+        Number(id),
+        calificacionId !== undefined ? Number(calificacionId) : undefined,
+        criterioEvaluacionId !== undefined ? Number(criterioEvaluacionId) : undefined,
+        slideId !== undefined ? Number(slideId) : undefined,
+        puntaje !== undefined ? Number(puntaje) : undefined,
+        comentario,
+        fragmentoAudioId !== undefined ? Number(fragmentoAudioId) : undefined,
+      ),
+    ];
+  }
+}

--- a/clean/src/domain/dtos/evaluacion/update-feedback-calificacion.dto.ts
+++ b/clean/src/domain/dtos/evaluacion/update-feedback-calificacion.dto.ts
@@ -1,0 +1,40 @@
+export class UpdateFeedbackCalificacionDto {
+  private constructor(
+    public readonly id: number,
+    public readonly calificacionId?: number,
+    public readonly observacion?: string,
+    public readonly fecha?: Date,
+    public readonly autor?: string,
+  ) {}
+
+  get values() {
+    const obj: { [key: string]: any } = {};
+    if (this.calificacionId !== undefined) obj.calificacionId = this.calificacionId;
+    if (this.observacion !== undefined) obj.observacion = this.observacion;
+    if (this.fecha) obj.fecha = this.fecha;
+    if (this.autor !== undefined) obj.autor = this.autor;
+    return obj;
+  }
+
+  static create(props: { [key: string]: any }): [string?, UpdateFeedbackCalificacionDto?] {
+    const { id, calificacionId, observacion, fecha, autor } = props;
+    if (id === undefined || isNaN(Number(id))) return ['id must be a valid number'];
+
+    let parsedDate: Date | undefined = undefined;
+    if (fecha) {
+      parsedDate = new Date(fecha);
+      if (parsedDate.toString() === 'Invalid Date') return ['fecha must be a valid date'];
+    }
+
+    return [
+      undefined,
+      new UpdateFeedbackCalificacionDto(
+        Number(id),
+        calificacionId !== undefined ? Number(calificacionId) : undefined,
+        observacion,
+        parsedDate,
+        autor,
+      ),
+    ];
+  }
+}

--- a/clean/src/domain/dtos/evaluacion/update-parametros-ideales.dto.ts
+++ b/clean/src/domain/dtos/evaluacion/update-parametros-ideales.dto.ts
@@ -1,0 +1,33 @@
+export class UpdateParametrosIdealesDto {
+  private constructor(
+    public readonly id: number,
+    public readonly claridadIdeal?: number,
+    public readonly velocidadIdeal?: number,
+    public readonly pausasIdeales?: number,
+    public readonly otrosParametros?: string,
+  ) {}
+
+  get values() {
+    const obj: { [key: string]: any } = {};
+    if (this.claridadIdeal !== undefined) obj.claridadIdeal = this.claridadIdeal;
+    if (this.velocidadIdeal !== undefined) obj.velocidadIdeal = this.velocidadIdeal;
+    if (this.pausasIdeales !== undefined) obj.pausasIdeales = this.pausasIdeales;
+    if (this.otrosParametros !== undefined) obj.otrosParametros = this.otrosParametros;
+    return obj;
+  }
+
+  static create(props: { [key: string]: any }): [string?, UpdateParametrosIdealesDto?] {
+    const { id, claridadIdeal, velocidadIdeal, pausasIdeales, otrosParametros } = props;
+    if (id === undefined || isNaN(Number(id))) return ['id must be a valid number'];
+    return [
+      undefined,
+      new UpdateParametrosIdealesDto(
+        Number(id),
+        claridadIdeal !== undefined ? Number(claridadIdeal) : undefined,
+        velocidadIdeal !== undefined ? Number(velocidadIdeal) : undefined,
+        pausasIdeales !== undefined ? Number(pausasIdeales) : undefined,
+        otrosParametros,
+      ),
+    ];
+  }
+}

--- a/clean/src/domain/dtos/index.ts
+++ b/clean/src/domain/dtos/index.ts
@@ -1,4 +1,13 @@
-
-
 export * from './todos/create-todo.dto';
 export * from './todos/update-todo.dto';
+
+export * from './evaluacion/create-calificacion.dto';
+export * from './evaluacion/update-calificacion.dto';
+export * from './evaluacion/create-criterio-evaluacion.dto';
+export * from './evaluacion/update-criterio-evaluacion.dto';
+export * from './evaluacion/create-detalle-calificacion.dto';
+export * from './evaluacion/update-detalle-calificacion.dto';
+export * from './evaluacion/create-feedback-calificacion.dto';
+export * from './evaluacion/update-feedback-calificacion.dto';
+export * from './evaluacion/create-parametros-ideales.dto';
+export * from './evaluacion/update-parametros-ideales.dto';


### PR DESCRIPTION
## Summary
- document each domain entity in README files
- add DTOs for evaluation entities
- fix import paths for evaluation datasources

## Testing
- `npm install`
- `npm run build` *(fails: Environment variable POSTGRES_URL not set)*

------
https://chatgpt.com/codex/tasks/task_e_6846f2edfea0832b8154109b2d67cbb5