### PR TITLE
Add JSON datasource for flashcards

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,30 +158,13 @@ Puedes usar el archivo `memory-datasource.http` para probar la funcionalidad con
 
 | Entidad | Descripción | Justificación |
 |---------|-------------|---------------|
-| **TodoEntity** | Representa una tarea por realizar con su texto y fecha de finalización opcional. | Sirve como ejemplo simple para exponer la arquitectura y probar los distintos datasources. |
-| **Calificacion** | Calificación global de una grabación realizada por un usuario, incluye puntaje, observaciones y fecha. | Permite almacenar la evaluación general y actúa como agregador de los detalles de cada criterio. |
-| **CriterioEvaluacion** | Define un criterio o aspecto a evaluar junto con su peso relativo. | Separa los distintos puntos que componen una calificación para un análisis más fino. |
-| **DetalleCalificacion** | Puntaje otorgado a un criterio en una diapositiva específica junto con comentarios y audio. | Registra la evaluación a nivel de detalle para identificar fortalezas y debilidades puntuales. |
-| **FeedbackCalificacion** | Retroalimentación textual asociada a una calificación en una fecha determinada. | Permite mantener un historial de comentarios y sugerencias sobre la presentación evaluada. |
-| **ParametrosIdeales** | Valores ideales de claridad, velocidad y pausas utilizados como referencia. | Sirven como guía para comparar las presentaciones contra un estándar deseado. |
+| **TodoEntity** | Representa una tarea simple y sirve como base para demostrar la arquitectura. | Ejemplo inicial para cualquier datasource. |
+| **Flashcard** | Tarjeta de estudio con pregunta, respuesta y categorías asociadas. | Es la unidad básica de aprendizaje. |
+| **FlashcardInteraction** | Registra cada vez que el usuario responde una tarjeta, indicando si fue correcta y el tiempo empleado. | Permite aplicar técnicas de memoria espaciada. |
 
 
 
-Las siguientes imágenes ilustran el flujo principal de la aplicación para evaluar grabaciones de presentaciones.
-
-1. **Listado de Calificaciones** – Se muestran todas las grabaciones evaluadas y su puntaje global (`Calificacion`).
-   ![I1](./clean/public/assets/images/I1.jpg)
-2. **Definición de Criterios** – El evaluador configura los aspectos a revisar (`CriterioEvaluacion`) y establece los parámetros ideales (`ParametrosIdeales`).
-   ![I2](./clean/public/assets/images/I2.jpg)
-3. **Registro de Detalles** – Durante la evaluación se califica cada diapositiva o sección generando un `DetalleCalificacion`.
-   ![I3](./clean/public/assets/images/I3.jpg)
-4. **Resumen de Resultados** – Una vez finalizada la revisión se muestra el puntaje final y se permite registrar observaciones.
-   ![I4](./clean/public/assets/images/I4.jpg)
-5. **Feedback Continuo** – Se pueden añadir mensajes de mejora (`FeedbackCalificacion`) para que el usuario realice nuevas grabaciones.
-   ![I5](./clean/public/assets/images/I5.jpg)
-
-Este flujo aprovecha las cinco entidades de evaluación para almacenar tanto los puntajes como las observaciones de cada presentación.
-=======
+## Escenario de Flashcards
 
 La primera imagen muestra un listado de flashcards para la administración de los usuarios.
 
@@ -203,4 +186,5 @@ En la quinta imagen mostramos que al dar vuelta a las flashcards se puede ver la
 
 ![I5](./clean/public/assets/images/I5.jpg)
 
+Cada iteración de los usuarios con las flashcards debe quedar almacenada para promover la memoria espaciada.
 

--- a/clean/README.md
+++ b/clean/README.md
@@ -158,30 +158,11 @@ Puedes usar el archivo `memory-datasource.http` para probar la funcionalidad con
 
 | Entidad | Descripción | Justificación |
 |---------|-------------|---------------|
-| **TodoEntity** | Representa una tarea por realizar con su texto y fecha de finalización opcional. | Sirve como ejemplo simple para exponer la arquitectura y probar los distintos datasources. |
-| **Calificacion** | Calificación global de una grabación realizada por un usuario, incluye puntaje, observaciones y fecha. | Permite almacenar la evaluación general y actúa como agregador de los detalles de cada criterio. |
-| **CriterioEvaluacion** | Define un criterio o aspecto a evaluar junto con su peso relativo. | Separa los distintos puntos que componen una calificación para un análisis más fino. |
-| **DetalleCalificacion** | Puntaje otorgado a un criterio en una diapositiva específica junto con comentarios y audio. | Registra la evaluación a nivel de detalle para identificar fortalezas y debilidades puntuales. |
-| **FeedbackCalificacion** | Retroalimentación textual asociada a una calificación en una fecha determinada. | Permite mantener un historial de comentarios y sugerencias sobre la presentación evaluada. |
-| **ParametrosIdeales** | Valores ideales de claridad, velocidad y pausas utilizados como referencia. | Sirven como guía para comparar las presentaciones contra un estándar deseado. |
+| **TodoEntity** | Representa una tarea simple y sirve como base para demostrar la arquitectura. | Ejemplo inicial para cualquier datasource. |
+| **Flashcard** | Tarjeta de estudio con pregunta, respuesta y categorías asociadas. | Es la unidad básica de aprendizaje. |
+| **FlashcardInteraction** | Registra cada vez que el usuario responde una tarjeta, indicando si fue correcta y el tiempo empleado. | Permite aplicar técnicas de memoria espaciada. |
 
-## Escenario de Evaluación
-
-Las siguientes imágenes ilustran el proceso para calificar grabaciones de presentaciones.
-
-1. **Listado de Calificaciones** – Se presentan todas las evaluaciones realizadas (`Calificacion`).
-   ![I1](./public/assets/images/I1.jpg)
-2. **Definición de Criterios** – El evaluador define los criterios (`CriterioEvaluacion`) y los parámetros ideales (`ParametrosIdeales`).
-   ![I2](./public/assets/images/I2.jpg)
-3. **Registro de Detalles** – Durante la revisión se genera un `DetalleCalificacion` por cada diapositiva o sección evaluada.
-   ![I3](./public/assets/images/I3.jpg)
-4. **Resumen de Resultados** – Al finalizar se muestra el puntaje global y se permite registrar observaciones.
-   ![I4](./public/assets/images/I4.jpg)
-5. **Feedback Continuo** – Es posible añadir `FeedbackCalificacion` para que el usuario mejore sus futuras presentaciones.
-   ![I5](./public/assets/images/I5.jpg)
-
-Estas imágenes reflejan cómo las cinco entidades se integran para gestionar las evaluaciones de manera completa.
-## Aplicación de Flashcards
+## Escenario de Flashcards
 
 La primera imagen muestra un listado de flashcards para la administración de los usuarios.
 

--- a/clean/src/data/flashcards.json
+++ b/clean/src/data/flashcards.json
@@ -1,0 +1,14 @@
+[
+  {
+    "id": 1,
+    "pregunta": "¿Qué es JavaScript?",
+    "respuesta": "Un lenguaje de programación.",
+    "categorias": ["programación", "web"]
+  },
+  {
+    "id": 2,
+    "pregunta": "¿Qué es TypeScript?",
+    "respuesta": "Un superset de JavaScript que añade tipos.",
+    "categorias": ["programación"]
+  }
+]

--- a/clean/src/domain/datasources/flashcards/flashcard.datasource.ts
+++ b/clean/src/domain/datasources/flashcards/flashcard.datasource.ts
@@ -1,0 +1,9 @@
+import { Flashcard } from '../../entities/flashcards/flashcard.entity';
+
+export abstract class FlashcardDatasource {
+  abstract create(flashcard: Flashcard): Promise<Flashcard>;
+  abstract getAll(): Promise<Flashcard[]>;
+  abstract findById(id: number): Promise<Flashcard>;
+  abstract update(flashcard: Flashcard): Promise<Flashcard>;
+  abstract deleteById(id: number): Promise<Flashcard>;
+}

--- a/clean/src/domain/dtos/evaluacion/create-calificacion.dto.ts
+++ b/clean/src/domain/dtos/evaluacion/create-calificacion.dto.ts
@@ -1,29 +1,26 @@
 export class CreateCalificacionDto {
   private constructor(
-    public readonly grabacionId: number,
     public readonly usuarioId: number,
     public readonly puntajeGlobal: number,
     public readonly observacionGlobal: string,
-    public readonly tipoCalificacion: string,
+    public readonly modoEstudio: string,
     public readonly fecha: Date,
     public readonly parametrosIdealesId?: number,
   ) {}
 
   static create(props: { [key: string]: any }): [string?, CreateCalificacionDto?] {
     const {
-      grabacionId,
       usuarioId,
       puntajeGlobal,
       observacionGlobal,
-      tipoCalificacion,
+      modoEstudio,
       fecha,
       parametrosIdealesId,
     } = props;
 
-    if (grabacionId === undefined) return ['grabacionId is required'];
     if (usuarioId === undefined) return ['usuarioId is required'];
     if (puntajeGlobal === undefined) return ['puntajeGlobal is required'];
-    if (!tipoCalificacion) return ['tipoCalificacion is required'];
+    if (!modoEstudio) return ['modoEstudio is required'];
     if (!fecha) return ['fecha is required'];
 
     const parsedDate = new Date(fecha);
@@ -32,11 +29,10 @@ export class CreateCalificacionDto {
     return [
       undefined,
       new CreateCalificacionDto(
-        Number(grabacionId),
         Number(usuarioId),
         Number(puntajeGlobal),
         observacionGlobal ?? '',
-        tipoCalificacion,
+        modoEstudio,
         parsedDate,
         parametrosIdealesId !== undefined ? Number(parametrosIdealesId) : undefined,
       ),

--- a/clean/src/domain/dtos/evaluacion/create-criterio-evaluacion.dto.ts
+++ b/clean/src/domain/dtos/evaluacion/create-criterio-evaluacion.dto.ts
@@ -2,13 +2,13 @@ export class CreateCriterioEvaluacionDto {
   private constructor(
     public readonly nombre: string,
     public readonly descripcion: string,
-    public readonly peso: number,
+    public readonly dificultad: number,
   ) {}
 
   static create(props: { [key: string]: any }): [string?, CreateCriterioEvaluacionDto?] {
-    const { nombre, descripcion, peso } = props;
+    const { nombre, descripcion, dificultad } = props;
     if (!nombre) return ['nombre is required'];
-    if (peso === undefined) return ['peso is required'];
-    return [undefined, new CreateCriterioEvaluacionDto(nombre, descripcion ?? '', Number(peso))];
+    if (dificultad === undefined) return ['dificultad is required'];
+    return [undefined, new CreateCriterioEvaluacionDto(nombre, descripcion ?? '', Number(dificultad))];
   }
 }

--- a/clean/src/domain/dtos/evaluacion/create-detalle-calificacion.dto.ts
+++ b/clean/src/domain/dtos/evaluacion/create-detalle-calificacion.dto.ts
@@ -2,37 +2,37 @@ export class CreateDetalleCalificacionDto {
   private constructor(
     public readonly calificacionId: number,
     public readonly criterioEvaluacionId: number,
-    public readonly slideId: number,
+    public readonly flashcardId: number,
     public readonly puntaje: number,
     public readonly comentario: string,
-    public readonly fragmentoAudioId: number,
+    public readonly tiempoRespuesta: number,
   ) {}
 
   static create(props: { [key: string]: any }): [string?, CreateDetalleCalificacionDto?] {
     const {
       calificacionId,
       criterioEvaluacionId,
-      slideId,
+      flashcardId,
       puntaje,
       comentario,
-      fragmentoAudioId,
+      tiempoRespuesta,
     } = props;
 
     if (calificacionId === undefined) return ['calificacionId is required'];
     if (criterioEvaluacionId === undefined) return ['criterioEvaluacionId is required'];
-    if (slideId === undefined) return ['slideId is required'];
+    if (flashcardId === undefined) return ['flashcardId is required'];
     if (puntaje === undefined) return ['puntaje is required'];
-    if (fragmentoAudioId === undefined) return ['fragmentoAudioId is required'];
+    if (tiempoRespuesta === undefined) return ['tiempoRespuesta is required'];
 
     return [
       undefined,
       new CreateDetalleCalificacionDto(
         Number(calificacionId),
         Number(criterioEvaluacionId),
-        Number(slideId),
+        Number(flashcardId),
         Number(puntaje),
         comentario ?? '',
-        Number(fragmentoAudioId),
+        Number(tiempoRespuesta),
       ),
     ];
   }

--- a/clean/src/domain/dtos/evaluacion/create-parametros-ideales.dto.ts
+++ b/clean/src/domain/dtos/evaluacion/create-parametros-ideales.dto.ts
@@ -1,23 +1,28 @@
 export class CreateParametrosIdealesDto {
   private constructor(
-    public readonly claridadIdeal: number,
-    public readonly velocidadIdeal: number,
-    public readonly pausasIdeales: number,
+    public readonly factorFacilidadInicial: number,
+    public readonly intervaloInicialDias: number,
+    public readonly repeticionesObjetivo: number,
     public readonly otrosParametros: string,
   ) {}
 
   static create(props: { [key: string]: any }): [string?, CreateParametrosIdealesDto?] {
-    const { claridadIdeal, velocidadIdeal, pausasIdeales, otrosParametros } = props;
-    if (claridadIdeal === undefined) return ['claridadIdeal is required'];
-    if (velocidadIdeal === undefined) return ['velocidadIdeal is required'];
-    if (pausasIdeales === undefined) return ['pausasIdeales is required'];
+    const {
+      factorFacilidadInicial,
+      intervaloInicialDias,
+      repeticionesObjetivo,
+      otrosParametros,
+    } = props;
+    if (factorFacilidadInicial === undefined) return ['factorFacilidadInicial is required'];
+    if (intervaloInicialDias === undefined) return ['intervaloInicialDias is required'];
+    if (repeticionesObjetivo === undefined) return ['repeticionesObjetivo is required'];
 
     return [
       undefined,
       new CreateParametrosIdealesDto(
-        Number(claridadIdeal),
-        Number(velocidadIdeal),
-        Number(pausasIdeales),
+        Number(factorFacilidadInicial),
+        Number(intervaloInicialDias),
+        Number(repeticionesObjetivo),
         otrosParametros ?? '',
       ),
     ];

--- a/clean/src/domain/dtos/evaluacion/update-calificacion.dto.ts
+++ b/clean/src/domain/dtos/evaluacion/update-calificacion.dto.ts
@@ -1,22 +1,20 @@
 export class UpdateCalificacionDto {
   private constructor(
     public readonly id: number,
-    public readonly grabacionId?: number,
     public readonly usuarioId?: number,
     public readonly puntajeGlobal?: number,
     public readonly observacionGlobal?: string,
-    public readonly tipoCalificacion?: string,
+    public readonly modoEstudio?: string,
     public readonly fecha?: Date,
     public readonly parametrosIdealesId?: number,
   ) {}
 
   get values() {
     const obj: { [key: string]: any } = {};
-    if (this.grabacionId !== undefined) obj.grabacionId = this.grabacionId;
     if (this.usuarioId !== undefined) obj.usuarioId = this.usuarioId;
     if (this.puntajeGlobal !== undefined) obj.puntajeGlobal = this.puntajeGlobal;
     if (this.observacionGlobal !== undefined) obj.observacionGlobal = this.observacionGlobal;
-    if (this.tipoCalificacion !== undefined) obj.tipoCalificacion = this.tipoCalificacion;
+    if (this.modoEstudio !== undefined) obj.modoEstudio = this.modoEstudio;
     if (this.fecha) obj.fecha = this.fecha;
     if (this.parametrosIdealesId !== undefined) obj.parametrosIdealesId = this.parametrosIdealesId;
     return obj;
@@ -25,11 +23,10 @@ export class UpdateCalificacionDto {
   static create(props: { [key: string]: any }): [string?, UpdateCalificacionDto?] {
     const {
       id,
-      grabacionId,
       usuarioId,
       puntajeGlobal,
       observacionGlobal,
-      tipoCalificacion,
+      modoEstudio,
       fecha,
       parametrosIdealesId,
     } = props;
@@ -46,11 +43,10 @@ export class UpdateCalificacionDto {
       undefined,
       new UpdateCalificacionDto(
         Number(id),
-        grabacionId !== undefined ? Number(grabacionId) : undefined,
         usuarioId !== undefined ? Number(usuarioId) : undefined,
         puntajeGlobal !== undefined ? Number(puntajeGlobal) : undefined,
         observacionGlobal,
-        tipoCalificacion,
+        modoEstudio,
         parsedDate,
         parametrosIdealesId !== undefined ? Number(parametrosIdealesId) : undefined,
       ),

--- a/clean/src/domain/dtos/evaluacion/update-criterio-evaluacion.dto.ts
+++ b/clean/src/domain/dtos/evaluacion/update-criterio-evaluacion.dto.ts
@@ -3,19 +3,19 @@ export class UpdateCriterioEvaluacionDto {
     public readonly id: number,
     public readonly nombre?: string,
     public readonly descripcion?: string,
-    public readonly peso?: number,
+    public readonly dificultad?: number,
   ) {}
 
   get values() {
     const obj: { [key: string]: any } = {};
     if (this.nombre !== undefined) obj.nombre = this.nombre;
     if (this.descripcion !== undefined) obj.descripcion = this.descripcion;
-    if (this.peso !== undefined) obj.peso = this.peso;
+    if (this.dificultad !== undefined) obj.dificultad = this.dificultad;
     return obj;
   }
 
   static create(props: { [key: string]: any }): [string?, UpdateCriterioEvaluacionDto?] {
-    const { id, nombre, descripcion, peso } = props;
+    const { id, nombre, descripcion, dificultad } = props;
     if (id === undefined || isNaN(Number(id))) return ['id must be a valid number'];
     return [
       undefined,
@@ -23,7 +23,7 @@ export class UpdateCriterioEvaluacionDto {
         Number(id),
         nombre,
         descripcion,
-        peso !== undefined ? Number(peso) : undefined,
+        dificultad !== undefined ? Number(dificultad) : undefined,
       ),
     ];
   }

--- a/clean/src/domain/dtos/evaluacion/update-detalle-calificacion.dto.ts
+++ b/clean/src/domain/dtos/evaluacion/update-detalle-calificacion.dto.ts
@@ -3,20 +3,20 @@ export class UpdateDetalleCalificacionDto {
     public readonly id: number,
     public readonly calificacionId?: number,
     public readonly criterioEvaluacionId?: number,
-    public readonly slideId?: number,
+    public readonly flashcardId?: number,
     public readonly puntaje?: number,
     public readonly comentario?: string,
-    public readonly fragmentoAudioId?: number,
+    public readonly tiempoRespuesta?: number,
   ) {}
 
   get values() {
     const obj: { [key: string]: any } = {};
     if (this.calificacionId !== undefined) obj.calificacionId = this.calificacionId;
     if (this.criterioEvaluacionId !== undefined) obj.criterioEvaluacionId = this.criterioEvaluacionId;
-    if (this.slideId !== undefined) obj.slideId = this.slideId;
+    if (this.flashcardId !== undefined) obj.flashcardId = this.flashcardId;
     if (this.puntaje !== undefined) obj.puntaje = this.puntaje;
     if (this.comentario !== undefined) obj.comentario = this.comentario;
-    if (this.fragmentoAudioId !== undefined) obj.fragmentoAudioId = this.fragmentoAudioId;
+    if (this.tiempoRespuesta !== undefined) obj.tiempoRespuesta = this.tiempoRespuesta;
     return obj;
   }
 
@@ -25,10 +25,10 @@ export class UpdateDetalleCalificacionDto {
       id,
       calificacionId,
       criterioEvaluacionId,
-      slideId,
+      flashcardId,
       puntaje,
       comentario,
-      fragmentoAudioId,
+      tiempoRespuesta,
     } = props;
 
     if (id === undefined || isNaN(Number(id))) return ['id must be a valid number'];
@@ -39,10 +39,10 @@ export class UpdateDetalleCalificacionDto {
         Number(id),
         calificacionId !== undefined ? Number(calificacionId) : undefined,
         criterioEvaluacionId !== undefined ? Number(criterioEvaluacionId) : undefined,
-        slideId !== undefined ? Number(slideId) : undefined,
+        flashcardId !== undefined ? Number(flashcardId) : undefined,
         puntaje !== undefined ? Number(puntaje) : undefined,
         comentario,
-        fragmentoAudioId !== undefined ? Number(fragmentoAudioId) : undefined,
+        tiempoRespuesta !== undefined ? Number(tiempoRespuesta) : undefined,
       ),
     ];
   }

--- a/clean/src/domain/dtos/evaluacion/update-parametros-ideales.dto.ts
+++ b/clean/src/domain/dtos/evaluacion/update-parametros-ideales.dto.ts
@@ -1,31 +1,37 @@
 export class UpdateParametrosIdealesDto {
   private constructor(
     public readonly id: number,
-    public readonly claridadIdeal?: number,
-    public readonly velocidadIdeal?: number,
-    public readonly pausasIdeales?: number,
+    public readonly factorFacilidadInicial?: number,
+    public readonly intervaloInicialDias?: number,
+    public readonly repeticionesObjetivo?: number,
     public readonly otrosParametros?: string,
   ) {}
 
   get values() {
     const obj: { [key: string]: any } = {};
-    if (this.claridadIdeal !== undefined) obj.claridadIdeal = this.claridadIdeal;
-    if (this.velocidadIdeal !== undefined) obj.velocidadIdeal = this.velocidadIdeal;
-    if (this.pausasIdeales !== undefined) obj.pausasIdeales = this.pausasIdeales;
+    if (this.factorFacilidadInicial !== undefined) obj.factorFacilidadInicial = this.factorFacilidadInicial;
+    if (this.intervaloInicialDias !== undefined) obj.intervaloInicialDias = this.intervaloInicialDias;
+    if (this.repeticionesObjetivo !== undefined) obj.repeticionesObjetivo = this.repeticionesObjetivo;
     if (this.otrosParametros !== undefined) obj.otrosParametros = this.otrosParametros;
     return obj;
   }
 
   static create(props: { [key: string]: any }): [string?, UpdateParametrosIdealesDto?] {
-    const { id, claridadIdeal, velocidadIdeal, pausasIdeales, otrosParametros } = props;
+    const {
+      id,
+      factorFacilidadInicial,
+      intervaloInicialDias,
+      repeticionesObjetivo,
+      otrosParametros,
+    } = props;
     if (id === undefined || isNaN(Number(id))) return ['id must be a valid number'];
     return [
       undefined,
       new UpdateParametrosIdealesDto(
         Number(id),
-        claridadIdeal !== undefined ? Number(claridadIdeal) : undefined,
-        velocidadIdeal !== undefined ? Number(velocidadIdeal) : undefined,
-        pausasIdeales !== undefined ? Number(pausasIdeales) : undefined,
+        factorFacilidadInicial !== undefined ? Number(factorFacilidadInicial) : undefined,
+        intervaloInicialDias !== undefined ? Number(intervaloInicialDias) : undefined,
+        repeticionesObjetivo !== undefined ? Number(repeticionesObjetivo) : undefined,
         otrosParametros,
       ),
     ];

--- a/clean/src/domain/entities/evaluacion/calificacion.entity.ts
+++ b/clean/src/domain/entities/evaluacion/calificacion.entity.ts
@@ -3,11 +3,10 @@ import { ParametrosIdeales } from './parametros-ideales.entity';
 export class Calificacion {
   constructor(
     public id: number,
-    public grabacionId: number,
     public usuarioId: number,
     public puntajeGlobal: number,
     public observacionGlobal: string,
-    public tipoCalificacion: string,
+    public modoEstudio: string,
     public fecha: Date,
     public parametrosIdeales?: ParametrosIdeales,
   ) {}
@@ -19,20 +18,18 @@ export class Calificacion {
   static fromObject(obj: Record<string, any>): Calificacion {
     const {
       id,
-      grabacionId,
       usuarioId,
       puntajeGlobal,
       observacionGlobal,
-      tipoCalificacion,
+      modoEstudio,
       fecha,
       parametrosIdeales,
     } = obj;
 
     if (id === undefined) throw 'id is required';
-    if (grabacionId === undefined) throw 'grabacionId is required';
     if (usuarioId === undefined) throw 'usuarioId is required';
     if (puntajeGlobal === undefined) throw 'puntajeGlobal is required';
-    if (!tipoCalificacion) throw 'tipoCalificacion is required';
+    if (!modoEstudio) throw 'modoEstudio is required';
     if (!fecha) throw 'fecha is required';
 
     const date = new Date(fecha);
@@ -44,11 +41,10 @@ export class Calificacion {
 
     return new Calificacion(
       id,
-      grabacionId,
       usuarioId,
       puntajeGlobal,
       observacionGlobal ?? '',
-      tipoCalificacion,
+      modoEstudio,
       date,
       param
     );

--- a/clean/src/domain/entities/evaluacion/criterio-evaluacion.entity.ts
+++ b/clean/src/domain/entities/evaluacion/criterio-evaluacion.entity.ts
@@ -3,15 +3,15 @@ export class CriterioEvaluacion {
     public id: number,
     public nombre: string,
     public descripcion: string,
-    public peso: number,
+    public dificultad: number,
   ) {}
 
   static fromObject(obj: Record<string, any>): CriterioEvaluacion {
-    const { id, nombre, descripcion, peso } = obj;
+    const { id, nombre, descripcion, dificultad } = obj;
     if (id === undefined) throw 'id is required';
     if (!nombre) throw 'nombre is required';
-    if (peso === undefined) throw 'peso is required';
+    if (dificultad === undefined) throw 'dificultad is required';
     const desc = descripcion ?? '';
-    return new CriterioEvaluacion(id, nombre, desc, peso);
+    return new CriterioEvaluacion(id, nombre, desc, dificultad);
   }
 }

--- a/clean/src/domain/entities/evaluacion/detalle-calificacion.entity.ts
+++ b/clean/src/domain/entities/evaluacion/detalle-calificacion.entity.ts
@@ -6,10 +6,10 @@ export class DetalleCalificacion {
     public id: number,
     public calificacion: Calificacion,
     public criterioEvaluacion: CriterioEvaluacion,
-    public slideId: number,
+    public flashcardId: number,
     public puntaje: number,
     public comentario: string,
-    public fragmentoAudioId: number,
+    public tiempoRespuesta: number,
   ) {}
 
   static fromObject(obj: Record<string, any>): DetalleCalificacion {
@@ -17,27 +17,27 @@ export class DetalleCalificacion {
       id,
       calificacion,
       criterioEvaluacion,
-      slideId,
+      flashcardId,
       puntaje,
       comentario,
-      fragmentoAudioId,
+      tiempoRespuesta,
     } = obj;
 
     if (id === undefined) throw 'id is required';
     if (!calificacion) throw 'calificacion is required';
     if (!criterioEvaluacion) throw 'criterioEvaluacion is required';
-    if (slideId === undefined) throw 'slideId is required';
+    if (flashcardId === undefined) throw 'flashcardId is required';
     if (puntaje === undefined) throw 'puntaje is required';
-    if (fragmentoAudioId === undefined) throw 'fragmentoAudioId is required';
+    if (tiempoRespuesta === undefined) throw 'tiempoRespuesta is required';
 
     return new DetalleCalificacion(
       id,
       Calificacion.fromObject(calificacion),
       CriterioEvaluacion.fromObject(criterioEvaluacion),
-      slideId,
+      flashcardId,
       puntaje,
       comentario ?? '',
-      fragmentoAudioId
+      tiempoRespuesta
     );
   }
 }

--- a/clean/src/domain/entities/evaluacion/parametros-ideales.entity.ts
+++ b/clean/src/domain/entities/evaluacion/parametros-ideales.entity.ts
@@ -1,19 +1,31 @@
 export class ParametrosIdeales {
   constructor(
     public id: number,
-    public claridadIdeal: number,
-    public velocidadIdeal: number,
-    public pausasIdeales: number,
+    public factorFacilidadInicial: number,
+    public intervaloInicialDias: number,
+    public repeticionesObjetivo: number,
     public otrosParametros: string,
   ) {}
 
   static fromObject(obj: Record<string, any>): ParametrosIdeales {
-    const { id, claridadIdeal, velocidadIdeal, pausasIdeales, otrosParametros } = obj;
+    const {
+      id,
+      factorFacilidadInicial,
+      intervaloInicialDias,
+      repeticionesObjetivo,
+      otrosParametros,
+    } = obj;
     if (id === undefined) throw 'id is required';
-    if (claridadIdeal === undefined) throw 'claridadIdeal is required';
-    if (velocidadIdeal === undefined) throw 'velocidadIdeal is required';
-    if (pausasIdeales === undefined) throw 'pausasIdeales is required';
+    if (factorFacilidadInicial === undefined) throw 'factorFacilidadInicial is required';
+    if (intervaloInicialDias === undefined) throw 'intervaloInicialDias is required';
+    if (repeticionesObjetivo === undefined) throw 'repeticionesObjetivo is required';
     const otros = otrosParametros ?? '';
-    return new ParametrosIdeales(id, claridadIdeal, velocidadIdeal, pausasIdeales, otros);
+    return new ParametrosIdeales(
+      id,
+      factorFacilidadInicial,
+      intervaloInicialDias,
+      repeticionesObjetivo,
+      otros
+    );
   }
 }

--- a/clean/src/domain/entities/flashcards/flashcard-interaction.entity.ts
+++ b/clean/src/domain/entities/flashcards/flashcard-interaction.entity.ts
@@ -1,0 +1,30 @@
+export class FlashcardInteraction {
+  constructor(
+    public id: number,
+    public flashcardId: number,
+    public userId: number,
+    public correcta: boolean,
+    public tiempoRespuesta: number,
+    public fecha: Date
+  ) {}
+
+  static fromObject(obj: Record<string, any>): FlashcardInteraction {
+    const { id, flashcardId, userId, correcta, tiempoRespuesta, fecha } = obj;
+    if (id === undefined) throw 'id is required';
+    if (flashcardId === undefined) throw 'flashcardId is required';
+    if (userId === undefined) throw 'userId is required';
+    if (correcta === undefined) throw 'correcta is required';
+    if (tiempoRespuesta === undefined) throw 'tiempoRespuesta is required';
+    if (!fecha) throw 'fecha is required';
+    const date = new Date(fecha);
+    if (isNaN(date.getTime())) throw 'fecha is not valid';
+    return new FlashcardInteraction(
+      id,
+      flashcardId,
+      userId,
+      Boolean(correcta),
+      tiempoRespuesta,
+      date
+    );
+  }
+}

--- a/clean/src/domain/entities/flashcards/flashcard.entity.ts
+++ b/clean/src/domain/entities/flashcards/flashcard.entity.ts
@@ -1,0 +1,16 @@
+export class Flashcard {
+  constructor(
+    public id: number,
+    public pregunta: string,
+    public respuesta: string,
+    public categorias: string[]
+  ) {}
+
+  static fromObject(obj: Record<string, any>): Flashcard {
+    const { id, pregunta, respuesta, categorias } = obj;
+    if (id === undefined) throw 'id is required';
+    if (!pregunta) throw 'pregunta is required';
+    if (!respuesta) throw 'respuesta is required';
+    return new Flashcard(id, pregunta, respuesta, categorias ?? []);
+  }
+}

--- a/clean/src/domain/index.ts
+++ b/clean/src/domain/index.ts
@@ -12,24 +12,16 @@ export * from './use-cases/todo/delete-todo';
 export * from './use-cases/todo/get-todo';
 export * from './use-cases/todo/get-todos';
 
+// Flashcards use-cases
+export * from './use-cases/flashcards/get-flashcards';
 
 
-// Evaluacion domain exports
-export * from './entities/evaluacion/calificacion.entity';
-export * from './entities/evaluacion/criterio-evaluacion.entity';
-export * from './entities/evaluacion/detalle-calificacion.entity';
-export * from './entities/evaluacion/feedback-calificacion.entity';
-export * from './entities/evaluacion/parametros-ideales.entity';
 
-export * from './repositories/evaluacion/calificacion.repository';
-export * from './repositories/evaluacion/criterio-evaluacion.repository';
-export * from './repositories/evaluacion/detalle-calificacion.repository';
-export * from './repositories/evaluacion/feedback-calificacion.repository';
-export * from './repositories/evaluacion/parametros-ideales.repository';
+// Flashcards domain exports
+export * from './entities/flashcards/flashcard.entity';
+export * from './entities/flashcards/flashcard-interaction.entity';
 
-export * from './datasources/evaluacion/calificacion.datasource';
-export * from './datasources/evaluacion/criterio-evaluacion.datasource';
-export * from './datasources/evaluacion/detalle-calificacion.datasource';
-export * from './datasources/evaluacion/feedback-calificacion.datasource';
-export * from './datasources/evaluacion/parametros-ideales.datasource';
+export * from './repositories/flashcards/flashcard.repository';
+
+export * from './datasources/flashcards/flashcard.datasource';
 

--- a/clean/src/domain/repositories/flashcards/flashcard.repository.ts
+++ b/clean/src/domain/repositories/flashcards/flashcard.repository.ts
@@ -1,0 +1,9 @@
+import { Flashcard } from '../../entities/flashcards/flashcard.entity';
+
+export abstract class FlashcardRepository {
+  abstract create(flashcard: Flashcard): Promise<Flashcard>;
+  abstract getAll(): Promise<Flashcard[]>;
+  abstract findById(id: number): Promise<Flashcard>;
+  abstract update(flashcard: Flashcard): Promise<Flashcard>;
+  abstract deleteById(id: number): Promise<Flashcard>;
+}

--- a/clean/src/domain/use-cases/flashcards/get-flashcards.ts
+++ b/clean/src/domain/use-cases/flashcards/get-flashcards.ts
@@ -1,0 +1,13 @@
+import { Flashcard } from '../../entities/flashcards/flashcard.entity';
+import { FlashcardRepository } from '../../repositories/flashcards/flashcard.repository';
+
+export interface GetFlashcardsUseCase {
+  execute(): Promise<Flashcard[]>;
+}
+
+export class GetFlashcards implements GetFlashcardsUseCase {
+  constructor(private readonly repository: FlashcardRepository) {}
+  execute(): Promise<Flashcard[]> {
+    return this.repository.getAll();
+  }
+}

--- a/clean/src/infrastructure/datasource/flashcard.json.datasource.ts
+++ b/clean/src/infrastructure/datasource/flashcard.json.datasource.ts
@@ -1,0 +1,77 @@
+import fs from 'fs';
+import path from 'path';
+import { Flashcard, FlashcardDatasource } from '../../domain';
+
+export class FlashcardJsonDatasource implements FlashcardDatasource {
+  private flashcards: Flashcard[] = [];
+  private nextId = 1;
+
+  constructor(private readonly filePath: string) {
+    this.loadData();
+  }
+
+  private loadData() {
+    try {
+      const abs = path.isAbsolute(this.filePath) ? this.filePath : path.join(process.cwd(), this.filePath);
+      if (fs.existsSync(abs)) {
+        const data = JSON.parse(fs.readFileSync(abs, 'utf8'));
+        if (Array.isArray(data)) {
+          this.flashcards = data.map(obj => Flashcard.fromObject(obj));
+          const ids = this.flashcards.map(f => f.id);
+          if (ids.length) this.nextId = Math.max(...ids) + 1;
+        }
+      }
+    } catch (error) {
+      console.error('Failed to load flashcards JSON:', error);
+      this.flashcards = [];
+    }
+  }
+
+  private saveData() {
+    try {
+      const abs = path.isAbsolute(this.filePath) ? this.filePath : path.join(process.cwd(), this.filePath);
+      const data = this.flashcards.map(f => ({
+        id: f.id,
+        pregunta: f.pregunta,
+        respuesta: f.respuesta,
+        categorias: f.categorias
+      }));
+      fs.writeFileSync(abs, JSON.stringify(data, null, 2), 'utf8');
+    } catch (error) {
+      console.error('Failed to save flashcards JSON:', error);
+    }
+  }
+
+  async create(flashcard: Flashcard): Promise<Flashcard> {
+    const newFlashcard = new Flashcard(this.nextId++, flashcard.pregunta, flashcard.respuesta, flashcard.categorias);
+    this.flashcards.push(newFlashcard);
+    this.saveData();
+    return newFlashcard;
+  }
+
+  async getAll(): Promise<Flashcard[]> {
+    return [...this.flashcards];
+  }
+
+  async findById(id: number): Promise<Flashcard> {
+    const flashcard = this.flashcards.find(f => f.id === id);
+    if (!flashcard) throw `Flashcard with id ${id} not found`;
+    return flashcard;
+  }
+
+  async update(flashcard: Flashcard): Promise<Flashcard> {
+    const index = this.flashcards.findIndex(f => f.id === flashcard.id);
+    if (index === -1) throw `Flashcard with id ${flashcard.id} not found`;
+    this.flashcards[index] = flashcard;
+    this.saveData();
+    return flashcard;
+  }
+
+  async deleteById(id: number): Promise<Flashcard> {
+    const index = this.flashcards.findIndex(f => f.id === id);
+    if (index === -1) throw `Flashcard with id ${id} not found`;
+    const [deleted] = this.flashcards.splice(index, 1);
+    this.saveData();
+    return deleted;
+  }
+}

--- a/clean/src/infrastructure/repositories/flashcard.repository.impl.ts
+++ b/clean/src/infrastructure/repositories/flashcard.repository.impl.ts
@@ -1,0 +1,21 @@
+import { Flashcard, FlashcardDatasource, FlashcardRepository } from '../../domain';
+
+export class FlashcardRepositoryImpl implements FlashcardRepository {
+  constructor(private readonly datasource: FlashcardDatasource) {}
+
+  create(flashcard: Flashcard): Promise<Flashcard> {
+    return this.datasource.create(flashcard);
+  }
+  getAll(): Promise<Flashcard[]> {
+    return this.datasource.getAll();
+  }
+  findById(id: number): Promise<Flashcard> {
+    return this.datasource.findById(id);
+  }
+  update(flashcard: Flashcard): Promise<Flashcard> {
+    return this.datasource.update(flashcard);
+  }
+  deleteById(id: number): Promise<Flashcard> {
+    return this.datasource.deleteById(id);
+  }
+}

--- a/clean/src/presentation/flashcards/controller.ts
+++ b/clean/src/presentation/flashcards/controller.ts
@@ -1,0 +1,14 @@
+import { Request, Response } from 'express';
+import { GetFlashcards } from '../../domain/use-cases/flashcards/get-flashcards';
+import { FlashcardRepository } from '../../domain';
+
+export class FlashcardsController {
+  constructor(private readonly repository: FlashcardRepository) {}
+
+  public getFlashcards = (req: Request, res: Response) => {
+    new GetFlashcards(this.repository)
+      .execute()
+      .then(data => res.json(data))
+      .catch(error => res.status(400).json({ error }));
+  };
+}

--- a/clean/src/presentation/flashcards/routes.ts
+++ b/clean/src/presentation/flashcards/routes.ts
@@ -1,0 +1,18 @@
+import { Router } from 'express';
+import path from 'path';
+import { FlashcardJsonDatasource } from '../../infrastructure/datasource/flashcard.json.datasource';
+import { FlashcardRepositoryImpl } from '../../infrastructure/repositories/flashcard.repository.impl';
+import { FlashcardsController } from './controller';
+
+export class FlashcardsRoutes {
+  static get routes(): Router {
+    const router = Router();
+    const filePath = path.join(__dirname, '../../data/flashcards.json');
+    const datasource = new FlashcardJsonDatasource(filePath);
+    const repository = new FlashcardRepositoryImpl(datasource);
+    const controller = new FlashcardsController(repository);
+
+    router.get('/', controller.getFlashcards);
+    return router;
+  }
+}

--- a/clean/src/presentation/routes.ts
+++ b/clean/src/presentation/routes.ts
@@ -3,6 +3,7 @@ import { Request, Response } from 'express';
 
 import { TodoRoutes } from './todos/routes';
 import { TodoMemoryRoutes } from './todos/routes.memory';
+import { FlashcardsRoutes } from './flashcards/routes';
 import { DatasourceConfig, DatasourceType } from '../infrastructure/datasource/datasource.config';
 
 
@@ -17,6 +18,7 @@ export class AppRoutes {
 
     router.use('/api/todos', TodoRoutes.routes );
     router.use('/api/todos-memory', TodoMemoryRoutes.routes );
+    router.use('/api/flashcards', FlashcardsRoutes.routes );
     
     // Endpoint de sistema para gestión de datasource
     router.get('/api/system/info', (req: Request, res: Response) => {


### PR DESCRIPTION
## Summary
- switch example domain to flashcards
- add Flashcard and FlashcardInteraction entities
- create JSON datasource and repository for flashcards
- expose GET /api/flashcards route

## Testing
- `npm install`
- `npm run build` *(fails: POSTGRES_URL not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846fd644e3c832b930bd8f4610d7f1c